### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A production-ready starter template for building Model Context Protocol (MCP) servers with TypeScript.
 
+<a href="https://glama.ai/mcp/servers/rlkcxdr2y9"><img width="380" height="200" src="https://glama.ai/mcp/servers/rlkcxdr2y9/badge" alt="Server Starter MCP server" /></a>
+
 ## 🚀 Quick Start
 
 1. Clone the repository


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Starter](https://glama.ai/mcp/servers/rlkcxdr2y9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/rlkcxdr2y9"><img width="380" height="200" src="https://glama.ai/mcp/servers/rlkcxdr2y9/badge" alt="Server Starter MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.